### PR TITLE
Add Heroku app.json

### DIFF
--- a/README-TEMPLATE.md
+++ b/README-TEMPLATE.md
@@ -39,20 +39,5 @@ You should run `sidekiq` to perform background jobs.
 
 Circle-CI deploys the master branch when it passes to https://brewhouse-rails-template.herokuapp.com
 
-The following add-ons should be added to your Heroku app:
-
-```
-heroku addons:create papertrail:choklad
-heroku addons:create newrelic:wayne
-heroku addons:create heroku-redis:hobby-dev
-heroku addons:create sendgrid:starter
-heroku addons:create rollbar:free
-```
-
-The following env variable should be set on your Heroku app:
-
-```
-heroku config:add HOST=brewhouse-rails-template.herokuapp.com
-heroku config:add PROTOCOL=https
-```
+Feel free to update the default heroku configuration in `app.json`.
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ rails app we work on.
 ### Production
 
 * `puma` 'cause it's fast
-* `rails_12factor` to run the app on heroku
+* `rails_12factor` to run the app on Heroku
 * `heroku-deflater` to compress assets
 * `rollbar` to get notified about errors
 * `newrelic_rpm` to monitor performances
-
+* `app.json` will setup add-ons, environment variables and run migrations when you deploy to Heroku

--- a/app.json
+++ b/app.json
@@ -1,0 +1,33 @@
+{
+  "name": "Brewhouse Rails Template",
+  "description": "Rails 4.2 app for Brewhouse Rails Template",
+  "keywords": [
+    "rails"
+  ],
+  "repository": "https://github.com/BrewhouseTeam/brewhouse-rails-template",
+  "success_url": "/",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate"
+  },
+  "env": {
+    "SECRET_TOKEN": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    },
+    "HOST": "brewhouse-rails-template.herokuapp.com",
+    "PROTOCOL": "https",
+    "RAILS_ENV": "production",
+    "RACK_ENV": "production",
+    "RAILS_SERVE_STATIC_FILES": "true"
+  },
+  "image": "heroku/ruby",
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "papertrail:choklad",
+    "newrelic:wayne",
+    "heroku-redis:hobby-dev",
+    "sendgrid:starter",
+    "rollbar:free"
+  ],
+  "buildpacks": []
+}

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   "repository": "https://github.com/BrewhouseTeam/brewhouse-rails-template",
   "success_url": "/",
   "scripts": {
-    "postdeploy": "bundle exec rake db:migrate"
+    "postdeploy": "bundle exec rake db:migrate db:seed"
   },
   "env": {
     "SECRET_TOKEN": {

--- a/bootstrap
+++ b/bootstrap
@@ -19,7 +19,7 @@ end
 
 def replace(changes)
   puts "Replacing #{changes.map { |from, to| %|"#{from} with "#{to}"| }.join(', ')}"
-  Dir['**/*', '.env*'].each do |file|
+  Dir["**/*", ".env*", "app.json"].each do |file|
     next if File.directory?(file)
 
     content = File.read(file)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,7 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+# This file should contain all the record creation needed to seed the database with sample values
+# for development and staging environments.
+#
+# Data required for production should go into a database migration.
 #
 # Examples:
 #


### PR DESCRIPTION
Add heroku's `app.json` to auto-setup add-ons, env vars and run migrations on deploy. It also enables heroku to automagically create a temporary heroku app for each PR.

Special thanks to @dmathieu for his lovely support.