### PR TITLE
Fix matching bug in cucumber `path_to` support helper

### DIFF
--- a/features/styleguide.feature
+++ b/features/styleguide.feature
@@ -5,6 +5,5 @@ Feature: Styleguide
   I want to see a styleguide
 
   Scenario: Display Styleguide
-    Given I go to the styleguide
+    Given I go to the styleguide page
     Then I should see the styleguide
-

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -7,8 +7,9 @@ module NavigationHelpers
       '/'
     else
       begin
-        page_name =~ /(the|my) (.*) page/
+        page_name =~ /(the|my) (.*)( page)?/
         path_components = $2.split(/\s+/)
+        path_components.pop() if path_components.last == "page" # ensures 'page' will never be appended to the path
         self.send(path_components.push('path').join('_'))
       rescue
         raise "Can't find mapping from \"#{page_name}\" to a path.\n" +

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -7,7 +7,7 @@ module NavigationHelpers
       '/'
     else
       begin
-        page_name =~ /(the|my) (.*)( page)?/
+        page_name =~ /(the|my) (.*) page/
         path_components = $2.split(/\s+/)
         self.send(path_components.push('path').join('_'))
       rescue


### PR DESCRIPTION
I was playing around with the Brewhouse Rails template tonight and found a bug in the `path_to` Cucumber helper. If you used "page" at the end of a step (i.e. "When I visit the sign up page") it would always include "page" instead of stripping it out. It was fixed in the Goodbits codebase, so I copied it in from over there.